### PR TITLE
Fix: Auto-scroll to details view on search

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,8 @@
 
                 // Show the pokemon details after fetching data
                 document.getElementById('pokemonDetails').style.display = 'block';
+
+                window.scrollTo({ top: 0, behavior: 'smooth' });
             } catch (error) {
                 alert(`Pokemon not found. Please try again.`);
             }


### PR DESCRIPTION
### Description

This pull request resolves the issue where the user had to manually scroll up to view a Pokémon's details after a successful search.

### Changes Made

- Added `window.scrollTo({ top: 0, behavior: 'smooth' });` to the `renderPokemon` function.
- This ensures that after the Pokémon data is displayed, the page automatically scrolls to the top, making the details immediately visible.

### How to Test

1.  Scroll down the page.
2.  Search for a valid Pokémon .
3.  Confirm that the page smoothly scrolls to the top to show the Pokémon's details.